### PR TITLE
fixing load balancing page menu hierarchy

### DIFF
--- a/content/topic-guides/load-balancer/Device-based-origin.md
+++ b/content/topic-guides/load-balancer/Device-based-origin.md
@@ -1,5 +1,5 @@
 ---
-title: Load Balancing - Device based origin selection
+title: Device based origin selection
 description: Use VCL to configure a layer 7 load balancer for different devices.
 keywords: content delivery network, CDN, load balancer, VCL, HTTP
 aliases:
@@ -19,7 +19,7 @@ Prerequisites:
 In your `default.vcl` file you can set a header that's recognizable in section.io's `last-proxy` to determine which origin address and host header to make the request with. So you are going to need to define that origin first in your `section.config.json` file located in the root of your applications git repo. You will be adding a key called `alternate_origins` under `environments.Production`.
 
 #### `section.config.json`
-    
+
     ...
     "environments": {
         "Production": {
@@ -50,14 +50,13 @@ Next we tell Varnish Cache to use this origin for requests if we detect the User
         call devicedetect;
         if ( req.http.device-type == "mobile" ) {
             set req.http.section-origin = "mobile_device";
-        } 
+        }
         ...
     }
 
 *Note 1:* Requests from non-mobile devices will be directed at the default origin of `203.0.113.1`.
-*Note 2:* If you are caching responses, make sure to `hash_data(req.http.section-origin)` to split the cache based on origin. 
+*Note 2:* If you are caching responses, make sure to `hash_data(req.http.section-origin)` to split the cache based on origin.
 
 #### Overview
 
 This use case is especially helpful if you are serving unique content to different devices or just to keep load off your default origin when the request is from a mobile device. section.io handles all the internals of actually making the request to your `mobile_device` origin and all you have to do is configure your reverse proxy setup in your git repo!
-

--- a/content/topic-guides/load-balancer/GEO-based-origin.md
+++ b/content/topic-guides/load-balancer/GEO-based-origin.md
@@ -1,5 +1,5 @@
 ---
-title: Load Balancing - GEO based origin selection
+title: GEO-based origin selection
 description: Use VCL to configure a layer 7 load balancer for differnet GEO locations.
 keywords: content delivery network, CDN, load balancer, VCL, HTTP
 aliases:
@@ -19,7 +19,7 @@ Prerequisites:
 In your `default.vcl` file you can set a header that's recognizable in section.io's `last-proxy` to determine which origin address and host header to make the request with. So you are going to need to define that origin first in your `section.config.json` file located in the root of your applications git repo. You will be adding a key called `alternate_origins` under `environments.Production`.
 
 #### `section.config.json`
-    
+
     ...
     "environments": {
         "Production": {
@@ -52,9 +52,8 @@ Next we tell Varnish Cache to use this origin for requests depending on the GEO 
     }
 
 *Note 1:* Requests not from US/CA/AU/NZ will be directed at the default origin of `203.0.113.1`.
-*Note 2:* If you are caching responses, make sure to `hash_data(req.http.section-origin)` to split the cache based on origin. 
+*Note 2:* If you are caching responses, make sure to `hash_data(req.http.section-origin)` to split the cache based on origin.
 
 #### Overview
 
 This use case is especially helpful if you are serving unique content to different geographic locations, such as offers only available in certain regions or pages in different languages or currencies or just to keep load separated between different origins. section.io handles all the internals of actually making the request to origins for each region and all you have to do is configure your reverse proxy setup in your git repo!
-

--- a/content/topic-guides/load-balancer/Static-asset-origin.md
+++ b/content/topic-guides/load-balancer/Static-asset-origin.md
@@ -1,5 +1,5 @@
 ---
-title: Load Balancing - Static asset origin
+title: Static asset origin
 description: Use VCL to configure a layer 7 load balancer for static assets.
 keywords: content delivery network, CDN, load balancer, VCL, HTTP
 aliases:
@@ -20,7 +20,7 @@ Prerequisites:
 In your `default.vcl` file you can set a header that's recognizable in section.io's `last-proxy` to determine which origin address and host header to make the request with. So you are going to need to define that origin first in your `section.config.json` file located in the root of your applications git repo. You will be adding a key called `alternate_origins` under `environments.Production`.
 
 #### `section.config.json`
-    
+
     ...
     "environments": {
         "Production": {
@@ -55,4 +55,3 @@ Next we need to tell Varnish Cache when to use and how to define this origin for
 #### Overview
 
 This use case is especially helpful if you are requesting your static assets on the same domain (e.g. `www.example.com`) to utilize HTTP/2, but want to take the load off your default origin when requesting static assets. section.io handles all the internals of actually making the request to your `assets` origin and all you have to do is configure your reverse proxy setup in your git repo!
-

--- a/content/topic-guides/load-balancer/_index.md
+++ b/content/topic-guides/load-balancer/_index.md
@@ -4,23 +4,19 @@ description: Use VCL to configure a layer 7 load balancer.
 keywords: content delivery network, CDN, load balancer, VCL, HTTP
 aliases:
   - /load-balancer/
-
 ---
 
 Load balancing distributes traffic across origin servers so that your website can handle more visitors at once and visitors are always directed to the best server for their requests. If one of your servers is not responding or a network is experiencing an outage, you can automatically redirect traffic to the closest functioning server so that your site stays up for all visitors.
 
 ## Technical details
 
-section.io provides a layer 7 load balancer to immediately route HTTP requests based on rules you set that can include request location, device or browser type, and cookies or headers. In addition, you can utilize our load balancer to randomly distribute requests to your origin servers so that no one server is overloaded. 
+section.io provides a layer 7 load balancer to immediately route HTTP requests based on rules you set that can include request location, device or browser type, and cookies or headers. In addition, you can utilize our load balancer to randomly distribute requests to your origin servers so that no one server is overloaded.
 
 section.io uses VCL to create common load balancing scenarios that can be easily set up in your section.io portal by editing your VCL files.
 
 ## Examples
 
-
-* **[Static asset origin](/docs/topic-guides/load-balancer/Static-asset-origin/)**.
-* **[GEO based origin selection](/docs/topic-guides/load-balancer/GEO-based-origin/)**.
-* **[Device based origin selection](/docs/topic-guides/load-balancer/Device-based-origin/)**.
+{{% children description="true" style="h3" %}}
 
 ### More examples coming soon
 


### PR DESCRIPTION
@interludic2000 The new pages that you added under Load Balancing are currently appearing as separate menu items in the left navigation. I updated the file structure to have the examples appear beneath the main Load Balancing page, so they only display when the menu is expanded.