### PR TITLE
Streamline performance tutorial

### DIFF
--- a/content/performance-techniques/tutorials/performance-action-plan/monitor-your-website.md
+++ b/content/performance-techniques/tutorials/performance-action-plan/monitor-your-website.md
@@ -7,7 +7,8 @@ aliases:
   - /topic-guides/performance-action-plan/monitor-your-website/
 ---
 
-**WHY** You may not want to be checking your metrics everyday, but you want to know if something is wrong so you can fix it. With Alerts you can set benchmarks for your metrics and be alerted via your preferred notification system.
+**WHY:** You may not want to be checking your metrics everyday, but you want to know if something is wrong so you can fix it. With Alerts you can set benchmarks for your metrics and be alerted via your preferred notification system.
 
-**HOW** Under the alerting tab you can identify a metric using graphite query string and at what value you want to be alerted. More details [here](https://www.section.io/docs/monitoring-and-alerting/).
+**HOW:** Under the alerting tab you can identify a metric using graphite query string and at what value you want to be alerted. More details [here](https://www.section.io/docs/monitoring-and-alerting/).
 
+For more in-depth guides on evaluating your website's performance and activity, see our [debugging](/docs/debugging/) and [monitoring](/docs/monitoring/) guides.

--- a/content/performance-techniques/tutorials/performance-action-plan/optimize-your-configuration.md
+++ b/content/performance-techniques/tutorials/performance-action-plan/optimize-your-configuration.md
@@ -7,6 +7,6 @@ aliases:
   - /topic-guides/performance-action-plan/optimize-your-configuration/
 ---
 
-**WHY** Based on your metrics evaluation, you should have identified areas you want to improve. These changes will help you get the most out of Section
+**WHY:** Based on your metrics evaluation, you should have identified areas you want to improve. These changes will help you get the most out of Section
 
-**HOW** To change your configurations, go to the proxy tab in your Section account. Here you can select configurations you want and we will write the code and deploy or for you. You can also go to the repository tab and edit the config file with your own code or edit using your command line. Details [here](https://www.section.io/docs/basic-configuration/). To learn about how to write code for your reverse proxy, visit the documentation for your selected proxy. For Varnish Cache 4.0 that is located [here](https://www.varnish-cache.org/docs/4.0/users-guide/vcl.html).
+**HOW:** To optimize your configuration, please visit our [modules page](/docs/modules/) and browse our guides on the modules in your stack.

--- a/content/performance-techniques/tutorials/performance-action-plan/review-your-metrics.md
+++ b/content/performance-techniques/tutorials/performance-action-plan/review-your-metrics.md
@@ -6,6 +6,6 @@ weight: 1
 aliases:
   - /topic-guides/performance-action-plan/review-your-metrics/
 ---
-**WHY** To understand how to improve your site, you first need a benchmark for where you are now.
+**WHY:** To understand how to improve your site, you first need a benchmark for where you are now.
 
-**HOW** After you go live, wait about an hour for data to populate.  While Section’s real time reporting will show data inside the first minute of go live, you should wait an hour for trends to emerge. Then use the evaluation guide above to look at your key metrics.
+**HOW:** After you go live, wait about an hour for data to populate.  While Section’s real time reporting will show data inside the first minute of go live, you should wait an hour for trends to emerge. Then use the evaluation guide above to look at your key metrics.

--- a/content/performance-techniques/tutorials/performance-action-plan/setup-your-local-environment.md
+++ b/content/performance-techniques/tutorials/performance-action-plan/setup-your-local-environment.md
@@ -7,6 +7,6 @@ aliases:
   - /topic-guides/performance-action-plan/setup-your-local-environment/
 ---
 
-**WHY** Before you make any changes to your cache configuration, we recommend you test them locally first. In order to test, you need to setup your local environment.
+**WHY:** Before you make any changes to your cache configuration, we recommend you test them locally first. In order to test, you need to setup your local environment.
 
-**HOW** Make sure you have git, vagrant, and virtual box on your local machine. Download section’s command line interface and run the section up command as described [here](https://www.section.io/docs/local-development/). If you do not want to do this step, you can skip it and make your changes live on production.
+**HOW:** To test configuration changes locally, visit our [Developer PoP tutorial](/docs/developer-workflow/). Many customers also choose to integrate a staging site with the Section platform as a part of their developer workflow. If you do not want to do this step, you can skip it and make your changes live on production.

--- a/content/performance-techniques/tutorials/performance-action-plan/track-your-changes.md
+++ b/content/performance-techniques/tutorials/performance-action-plan/track-your-changes.md
@@ -7,6 +7,6 @@ aliases:
   - /topic-guides/performance-action-plan/track-your-changes/
 ---
 
-**WHY**  Everytime you change your configuraiton, Section will log that history. This allows you to see what was changed and then review metrics to see how your site performed before and after the change.
+**WHY:** Everytime you change your configuration, Section will log that history. This allows you to see what was changed and then review metrics to see how your site performed before and after the change.
 
-**HOW** In the repository tab under commits you will see a list of the commits that have been made to your application. You can see what that looks like for Bootcamp [here](https://aperture.section.io/account/1/application/1/repository##repo%2Fcommits%2FProduction).
+**HOW:** In the repository tab under commits you will see a list of the commits that have been made to your application. You can see what that looks like for Bootcamp [here](https://aperture.section.io/account/1/application/1/repository##repo%2Fcommits%2FProduction).

--- a/content/performance-techniques/tutorials/performance-evaluation/discover-your-quick-cache-wins.md
+++ b/content/performance-techniques/tutorials/performance-evaluation/discover-your-quick-cache-wins.md
@@ -11,21 +11,21 @@ aliases:
 
 * HTML is the set of instructions required to load the page.
 * Images are any images or icons you load.
-* CSS is the style instruction for how to load images, text, and content on the page. And
+* CSS is the style instruction for how to load images, text, and content on the page.
 * JS is small scripts your browser will run as when it is instructed to by the HTML.
 
 You can view your hit rates, volume of requests, and time to serve for each of these different content types.
 
 **Why do you care?:** Understanding which types are being requested the most, require the most time to serve, and are being cached the most frequently helps you understand where your quick wins are to get started optimizing your cache configurations.
 
-Most of the time, images and CSS will be the easiest to get some cache wins and HTML is the most likely to give you your biggest performance and scalability wins as the hit rate increases.
+Most of the time, images and CSS will be the easiest place to boost cache rate. HTML, on the other hand, can be more difficult to cache successfully but often provides the largest  performance and scalability wins as the hit rate increases.
 
 **How do you see it?:** There are two dashboards in Grafana under `Real Time -> Monitoring` to understand content type caching.
 
-First, is request performance which shows throughput and time to serve by status. You can access this for Bootcamp **[here](https://aperture.section.io/account/1/application/1/grafana-web)**.
+The **request performance** dashboard shows throughput and time to serve by status. You can access this for Bootcamp **[here](https://aperture.section.io/account/1/application/1/grafana-web)**.
 
 {{% figure src="/docs/images/content-type-cache-performance-metrics.png" %}}
 
-Second, is asset cache hit rates which shows the hit rate by content type. You can access this for Bootcamp **[here](https://aperture.section.io/account/1/application/1/grafana-web)**.
+The **asset cache hit rates** dashboard shows the hit rate by content type. You can access this for Bootcamp **[here](https://aperture.section.io/account/1/application/1/grafana-web)**.
 
 {{% figure src="/docs/images/content-type-hit-rate.png" %}}

--- a/content/performance-techniques/tutorials/performance-evaluation/understand-if-your-varnish-cache-is-effective.md
+++ b/content/performance-techniques/tutorials/performance-evaluation/understand-if-your-varnish-cache-is-effective.md
@@ -7,14 +7,17 @@ aliases:
   - /topic-guides/performance-evaluation/understand-if-your-varnish-cache-id-effective/
 ---
 
-**What is it?:** How effectively customer requests are being answered by the cache. A hit means that the request was answered by the cache. A miss means that the request went to the cache but could not answer the request. A pass means that the request didn’t look at the cache to answer the request. The goal is to increase Hit % and decrease Miss and Pass %. A good starting goal would be 50% Hit.
+A key metric when evaluating website performance is **cache hit rate**. Cache hit rate is a measure of how effectively the cache is responding to customer requests. Whenever a request reaches a Varnish Cache instance, one of four outcomes occurs: hit, miss, pass, or synth.
 
-**Why do you care?:** When a customer request is answered by the cache, the request did not need to be answered by your website server. This improves page load time for your users which can increase revenue and decreases work required by your servers which reduces cost.
+A **hit** means that the cache responded to the request with a cached resource. A **miss** means that the cache tried to respond to the request with a cached resource but could not do so because it did not have a copy of the requested resource in its memory. A **pass** means that the cache did not even try to look up a response for the requested resource — often users specifically instruct Varnish Cache to pass on urls that should never be served from cache like `/checkout`, but there are other causes as well. From a performance standpoint, the goal is to increase Hit % and decrease Miss and Pass %.
 
-**How do you see it?:** This is the first chart we show you on the Section dashboard. For the Bootcamp application, the url is **[here](https://aperture.section.io/account/1/application/1/environment/Production/overview)**.
+**Why do you care?:** Whenever the cache answers a customer request, that means the request did not need to be answered by your website origin server. Having a large percentage of cache hits results in performance benefits and reduced costs.
+
+From a performance standpoint, Varnish Cache's quick lookup and response time combined with the geographic distribution of Section's platform means that your users are quickly served a response from a server close to their geographical location. This improves time-to-first-byte and keeps latency low. From a cost-savings perspective, every request that receives a response from cache does not need to connect to your origin server, greatly reducing load. With a finely-tuned caching configuration, your origin only needs to respond to requests for personalized actions such as checkout and and account pages.  
+
+**How do you see it?:** This is the first chart we show you on the Section dashboard. To see this in action on our demo bootcamp application, go **[here](https://aperture.section.io/account/1/application/1/environment/Production/overview)**.
 
 
 {{% figure src="/docs/images/varnish-cache-usage-metrics.png" %}}
 
-For more detailed information, such as the absolute number of requests and size of those requests, you can view Trending Metrics **[here](https://aperture.section.io/account/1/application/1/environment/Production/metrics##1)**.
-
+For more detailed information, such as the absolute number of requests and size of those requests, you can view Trending Metrics **[here](https://aperture.section.io/account/1/application/1/grafana-web)**. For more in-depth guidance on using our Monitoring tools, see [the monitoring section](/docs/monitoring/) of our documentation. 


### PR DESCRIPTION
remove references to the section cli and places where we ask customers to ask us to implement performance recommendations for them. 

Also streamlined and clarified some wording. 