### PR TITLE
Fix capitalisation of proper nouns. Use DOS line endings consistently

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ home = [ "HTML", "RSS", "JSON"]
 
 [[menu.shortcuts]]
 pre = "<h3>More</h3>"
-name = "<i class='fa fa-github'></i> Github repo"
+name = "<i class='fa fa-github'></i> GitHub repo"
 identifier = "ds"
 url = "https://github.com/section-io/docs"
 weight = 10

--- a/content/getting-started/overview/better-than-a-cdn.md
+++ b/content/getting-started/overview/better-than-a-cdn.md
@@ -5,21 +5,21 @@ aliases:
   - /tutorials/overview/better-than-a-cdn/
 ---
 
-The Section platform provides superior application performance, availability, scalability, and security by putting architects, developers, and sysadmins in the driver's seat. 
+The Section platform provides superior application performance, availability, scalability, and security by putting architects, developers, and sysadmins in the driver's seat.
 
 Unlike legacy CDN's, Section has designed an Application Edge system for modern agile development.
 
 Section differs from contemporary CDN platforms by:
 
-* allowing a choice of reverse proxy technology.
-* allowing engineers to use normal tooling to configure the system.
-* providing a real time devops toolset.
+- allowing a choice of reverse proxy technology.
+- allowing engineers to use normal tooling to configure the system.
+- providing a real time DevOps toolset.
 
 Unlike with legacy CDNs, with Section:
 
-* **there is no "one size fits all"**. Legacy CDNs have a single architecture that may or may not suit your needs now and into the future.
-* **there is no "push and pray"**. With full integration into the development lifecycle, the Section platform allows you to test new proxy configurations on your laptop before go-live with our [Developer PoP]({{< relref "developer-workflow/tutorials/developing-with-the-developer-pop.md" >}}).
-* **there is no "visibility gap"**. Legacy CDNs are slow to deliver diagnostics, and offer no analytics tools to turn raw data into actionable insight. We provide dynamic and detailed logs of how your traffic is passing through our system.  
+- **there is no "one size fits all"**. Legacy CDNs have a single architecture that may or may not suit your needs now and into the future.
+- **there is no "push and pray"**. With full integration into the development lifecycle, the Section platform allows you to test new proxy configurations on your laptop before go-live with our [Developer PoP]({{< relref "developer-workflow/tutorials/developing-with-the-developer-pop.md" >}}).
+- **there is no "visibility gap"**. Legacy CDNs are slow to deliver diagnostics, and offer no analytics tools to turn raw data into actionable insight. We provide dynamic and detailed logs of how your traffic is passing through our system.
 
 Section is ready to handle your workload regardless of the number of sites you have or the size of your traffic.
 

--- a/content/getting-started/overview/devops-ready.md
+++ b/content/getting-started/overview/devops-ready.md
@@ -1,5 +1,5 @@
 ---
-title: Devops Ready
+title: DevOps Ready
 weight: 7
 aliases:
   - /tutorials/overview/devops-ready/
@@ -11,9 +11,9 @@ Section runs a detailed, real-time logging and metrics platform to provide you w
 
 DevOps teams need a few things to get their job done well:
 
-* **Continual improvement**: Section collects hundreds of metrics about how your HTTP traffic is performing and provides long term retenion out of the box.
-* **Incident detection**: Section allows you to configure alerts for any metric in the platform.
-* **Incident management**: when things go wrong, use the real time metrics to identify problems and then dig right into the HTTP logs to isolate individual requests.
+- **Continual improvement**: Section collects hundreds of metrics about how your HTTP traffic is performing and provides long term retention out of the box.
+- **Incident detection**: Section allows you to configure alerts for any metric in the platform.
+- **Incident management**: when things go wrong, use the real time metrics to identify problems and then dig right into the HTTP logs to isolate individual requests.
 
 Legacy CDNs fall short of these needs in a couple of ways: either their log shipping latency is too slow (sometimes an hour after your problem started), or they fail to process those logs into meaningful and actionable information.
 

--- a/content/modules/_index.md
+++ b/content/modules/_index.md
@@ -6,7 +6,7 @@ aliases:
   - /proxy-list/
   - /reference/proxy-list/
 weight: 150
-ordersectionsby: "title"
+ordersectionsby: 'title'
 ---
 
 Section offers a number of different modules that can be used in your edge deployment.
@@ -17,19 +17,19 @@ If you want to experiment with different modules you can use our [Developer Work
 
 ## Available Modules
 
-| Module | Function | Description
-|:--|:--|---|
-| [Cloudinary](/docs/modules/cloudinary/ "Cloudinary overview") | Image Optimization | On-the-fly image manipulation and optimization. |
-| [Kraken](/docs/modules/kraken/ "Kraken overview") | Image Optimization | Optimize images and reduce page weight and load time. |
-| [ModSecurity](/docs/modules/modsecurity/ "ModSecurity") | Web Application Firewall | Open source Web Application Firewall. |
-| [Node.js](/docs/modules/nodejs/ "Node.js overview") | Edge Compute | Node.js Javascript application module running on Section compute edge. |
-| [OpenResty](/docs/modules/openresty/ "OpenResty overview") | Edge Compute | Nginx and Lua based scriptable web platform. |
-| [PageSpeed](/docs/modules/pagespeed/ "PageSpeed overview") | Front End Optimization | Optimize images, minify Javascript and CSS, defer Javascript libraries and more. |
-| [ShieldSquare](/docs/modules/shieldsquare/ "ShieldSquare overview") | Bot Management | Non-human bot traffic detection and management. |
-| [Signal Sciences](/docs/modules/signal-sciences/ "Signal Sciences overview") | Web Application Firewall | Real-time protection for an application under attack and integrates into devops toolchains. |
-| [SiteSpect](/docs/modules/sitespect/ "SiteSpect overview") | A/B Testing | Javascript and Tag Free A/B testing. |
-| [ThreatX](/docs/modules/threat-x/ "ThreatX overview") | Web Application Firewall | Web Application Firewall based on dynamic rules. |
-| [Varnish Cache](/docs/modules/varnish-cache/ "Varnish overview") | Cache | Latest version of Varnish Cache completely customizable. |
-| [Virtual Waiting Room](/docs/modules/virtual-waiting-room/ "Virtual Waiting Room overview") | Traffic Management | Manage user experience during extreme traffic events. |
+| Module                                                                                      | Function                 | Description                                                                                 |
+| :------------------------------------------------------------------------------------------ | :----------------------- | ------------------------------------------------------------------------------------------- |
+| [Cloudinary](/docs/modules/cloudinary/ 'Cloudinary overview')                               | Image Optimization       | On-the-fly image manipulation and optimization.                                             |
+| [Kraken](/docs/modules/kraken/ 'Kraken overview')                                           | Image Optimization       | Optimize images and reduce page weight and load time.                                       |
+| [ModSecurity](/docs/modules/modsecurity/ 'ModSecurity')                                     | Web Application Firewall | Open source Web Application Firewall.                                                       |
+| [Node.js](/docs/modules/nodejs/ 'Node.js overview')                                         | Edge Compute             | Node.js Javascript application module running on Section compute edge.                      |
+| [OpenResty](/docs/modules/openresty/ 'OpenResty overview')                                  | Edge Compute             | Nginx and Lua based scriptable web platform.                                                |
+| [PageSpeed](/docs/modules/pagespeed/ 'PageSpeed overview')                                  | Front End Optimization   | Optimize images, minify Javascript and CSS, defer Javascript libraries and more.            |
+| [ShieldSquare](/docs/modules/shieldsquare/ 'ShieldSquare overview')                         | Bot Management           | Non-human bot traffic detection and management.                                             |
+| [Signal Sciences](/docs/modules/signal-sciences/ 'Signal Sciences overview')                | Web Application Firewall | Real-time protection for an application under attack and integrates into DevOps toolchains. |
+| [SiteSpect](/docs/modules/sitespect/ 'SiteSpect overview')                                  | A/B Testing              | Javascript and Tag Free A/B testing.                                                        |
+| [ThreatX](/docs/modules/threat-x/ 'ThreatX overview')                                       | Web Application Firewall | Web Application Firewall based on dynamic rules.                                            |
+| [Varnish Cache](/docs/modules/varnish-cache/ 'Varnish overview')                            | Cache                    | Latest version of Varnish Cache completely customizable.                                    |
+| [Virtual Waiting Room](/docs/modules/virtual-waiting-room/ 'Virtual Waiting Room overview') | Traffic Management       | Manage user experience during extreme traffic events.                                       |
 
 {{% children %}}


### PR DESCRIPTION
What it says on the tin. 

Proper nouns include: 

- `/devops/i` => `"DevOps"`
- `/github/i` => `"GitHub"`

Apologies for the messy diff. 