### PR TITLE
remove email disclaimer

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -12,10 +12,6 @@ If you don't have a Section account then this is a good place to get started.
 
 Please contact us and a Section engineer will reach out to you directly: https://www.section.io/contact-us/
 
-{{% notice note %}}
-We do not subscribe you to any email lists and guarantee a direct interaction with an engineer who will understand the problem you are looking to solve.
-{{% /notice %}}
-
 By engaging Section's Customer Reliability Engineers, you'll have a great experience getting set up on Section's Edge Compute Platform and quickly achieve the outcomes you are seeking.
 
 ### General topic guides


### PR DESCRIPTION
I came across this note on the Getting Started section, and suggest removing it because:
1. All aperture users are added to our monthly customer newsletter and product announcements lists.
2. With new digital acquisition flows, they're not guaranteed to be directly connected to an engineer on their first interaction.

![Screen Shot 2020-08-27 at 9 49 15 AM](https://user-images.githubusercontent.com/18599354/91465098-99931a80-e84a-11ea-8552-e49f51174b9d.png)
