### PR TITLE
docs(HTTPS Logs): Remove dead link

### DIFF
--- a/content/explanations/section/https-logs.md
+++ b/content/explanations/section/https-logs.md
@@ -32,5 +32,4 @@ If you want to analyze your website using Graphite, start by grouping metrics su
 * [Basic Logging and Search](/docs/debugging/how-tos/basic-logging/ "Basic Logging and Search")
 * [Custom Logging and Search](/docs/debugging/how-tos/custom-logging/ "Custom Logging and Search")
 * [Debugging Howtos](/docs/debugging/how-tos/ "Debugging Howtos")
-* [Debugging Reference Guides](/docs/debugging/reference/ "Debugging Reference Guides")
 


### PR DESCRIPTION
## Description:
Debugging reference guide leads to a 404 (https://www.section.io/docs/debugging/reference/). I wasn't able to find the intended page.